### PR TITLE
 FEATURE: BIDS to nnUnet Conversion Script Addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# folders to ignore
+nnUNet_raw/
+nnUNet_preprocessed/
+nnUNet_results/
+.vscode/
+
+# files to ignore
+subject_to_case_identifier.json

--- a/README.md
+++ b/README.md
@@ -45,3 +45,58 @@ To test the performance of this model, use
 ivadomed --test -c path_to_config_file.json
 ```
 The evaluation results will be saved in `"path_output"/results_eval/evaluation_3Dmetrics.csv`
+
+
+## Train and test with nnUNetv2
+
+### Structure of the `nn_unet_scripts` Directory
+
+This directory contains the following components:
+
+- **Conversion Script**: This script is responsible for converting the Touching Myelin Boundary Detection Dataset from the BIDS format to the format expected by nnUNetv2. To run execute the following command: 
+```bash
+python scripts/convert_from_bids_to_nnunetv2_format.py <PATH/TO/ORIGINAL/DATASET> --TARGETDIR <PATH/TO/NEW/DATASET>
+```
+- **Train Test Split File**: This file is a JSON file that contains the training and testing split for the dataset. It is used by the conversion script above. The file should be named `train_test_split.json` and placed in the same directory as the dataset.
+
+
+
+### Getting Started
+
+To set up the environment and run the scripts, follow these steps:
+
+1. Create a new conda environment:
+```bash
+conda create --name sem_seg
+```
+2. Activate the environment:
+```bash
+conda activate sem_seg
+```
+3. Install PyTorch, torchvision, and torchaudio. For NeuroPoly lab members using the GPU servers, use the following command:
+```bash
+conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
+```
+For others, please refer to the PyTorch installation guide at https://pytorch.org/get-started/locally/ to get the appropriate command for your system.
+4. Update the environment with the remaining dependencies:
+```bash
+conda env update --file environment.yaml
+```
+5. Run the conversion script (the default target directory is the current working directory):
+```bash
+export RESULTS_DIR="<PATH/TO/SAVE/RESULTS>"
+```
+6. Set up the necessary environment variables:
+```bash
+python scripts/convert_from_bids_to_nnunetv2_format.py <PATH/TO/ORIGINAL/DATASET> --TARGETDIR $RESULTS_DIR
+```
+7. Set up the necessary environment variables:
+```bash
+export nnUNet_raw="$RESULTS_DIR/nnUNet_raw"
+export nnUNet_preprocessed="$RESULTS_DIR/nnUNet_preprocessed"
+export nnUNet_results="$RESULTS_DIR/nnUNet_results"
+```
+8. Run the nnUNet preprocessing command:
+```bash
+nnUNetv2_plan_and_preprocess -d 1 --verify_dataset_integrity
+```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python scripts/convert_from_bids_to_nnunetv2_format.py <PATH/TO/ORIGINAL/DATASET
 
 
 
-### Getting Started
+### Setting Up Conda Environment
 
 To set up the environment and run the scripts, follow these steps:
 
@@ -78,25 +78,18 @@ conda activate sem_seg
 conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
 ```
 For others, please refer to the PyTorch installation guide at https://pytorch.org/get-started/locally/ to get the appropriate command for your system.
+
 4. Update the environment with the remaining dependencies:
 ```bash
 conda env update --file environment.yaml
 ```
-5. Run the conversion script (the default target directory is the current working directory):
+### Setting Up nnUNet
+1. Activate the environment:
 ```bash
-export RESULTS_DIR="<PATH/TO/SAVE/RESULTS>"
+conda activate sem_seg
 ```
-6. Set up the necessary environment variables:
+
+2. To train the model, first, you need to set up nnUNet and preprocess the dataset. This can be done by running the setup script:
 ```bash
-python scripts/convert_from_bids_to_nnunetv2_format.py <PATH/TO/ORIGINAL/DATASET> --TARGETDIR $RESULTS_DIR
-```
-7. Set up the necessary environment variables:
-```bash
-export nnUNet_raw="$RESULTS_DIR/nnUNet_raw"
-export nnUNet_preprocessed="$RESULTS_DIR/nnUNet_preprocessed"
-export nnUNet_results="$RESULTS_DIR/nnUNet_results"
-```
-8. Run the nnUNet preprocessing command:
-```bash
-nnUNetv2_plan_and_preprocess -d 1 --verify_dataset_integrity
+source nn_unet_scripts/setup_nnunet.sh <PATH/TO/ORIGINAL/DATASET> <PATH/TO/SAVE/RESULTS>
 ```

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,7 @@
+name: sem_seg
+channels:
+  - defaults
+dependencies:
+  - pip:
+      - opencv-python==4.8.1.78
+      - nnunetv2==2.2.1

--- a/nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py
+++ b/nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py
@@ -124,6 +124,8 @@ def process_labels(
         Dictionary mapping subject names to case IDs.
     dataset_name : str
         Name of the dataset.
+    label_type : Literal["axonmyelin", "myelin", "axon"], optional
+        Type of label to use. Options are 'axonmyelin', 'myelin', or 'axon'. Defaults to 'axonmyelin'.
     """
     label_type_to_divisor = {"axonmyelin": 127, "myelin": 255, "axon": 255}
     for subject in particpant_to_sample_dict.keys():

--- a/nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py
+++ b/nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+Prepares a new dataset for nnUNetv2, focusing on SEM segmentation.
+
+Features:
+- Training Set Compilation: Includes all subjects with annotations in the 
+  training set. nnUNetv2 will perform automatic cross-validation using these 
+  annotated subjects.
+- Testing Set Assignment: Allocates subjects without annotations to the 
+  testing set, facilitating model performance evaluation on unseen data.
+- Inspiration: The structure and methodology of this script is
+  inspired by Armand Collin's work. The original script by Armand Collin can
+  be found at:
+  https://github.com/axondeepseg/model_seg_rabbit_axon-myelin_bf/blob/main/nnUNet_scripts/prepare_data.py
+"""
+
+
+__author__ = "Arthur Boschet"
+__license__ = "MIT"
+
+
+import argparse
+import csv
+import json
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Literal
+
+import cv2
+import numpy as np
+
+
+def create_directories(base_dir: str, subdirs: List[str]):
+    """
+    Creates subdirectories in a specified base directory.
+
+    Parameters
+    ----------
+    base_dir : str
+        The base directory where subdirectories will be created.
+    subdirs : List[str]
+        A list of subdirectory names to create within the base directory.
+    """
+    for subdir in subdirs:
+        os.makedirs(os.path.join(base_dir, subdir), exist_ok=True)
+
+
+def save_json(data: Dict, file_path: str):
+    """
+    Saves a dictionary as a JSON file at the specified path.
+
+    Parameters
+    ----------
+    data : Dict
+        Dictionary to be saved as JSON.
+    file_path : str
+        File path where the JSON file will be saved.
+    """
+    with open(file_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def process_images(
+    datapath: Path,
+    out_folder: str,
+    particpant_to_sample_dict: Dict[str, List[str]],
+    bids_to_nnunet_dict: Dict[str, int],
+    dataset_name: str,
+    is_test: bool = False,
+):
+    """
+    Processes all image files in each subject's directory.
+
+    Parameters
+    ----------
+    datapath : Path
+        Path to the data directory.
+    out_folder : str
+        Output directory to save processed images.
+    particpant_to_sample_dict : Dict[str, List[str]]
+        Dictionary mapping participant IDs to sample IDs.
+    bids_to_nnunet_dict : Dict[str, int]
+        Dictionary mapping subject names to case IDs.
+    dataset_name : str
+        Name of the dataset.
+    is_test : bool, optional
+        Boolean flag indicating if the images are for testing, by default False.
+    """
+    folder_type = "imagesTs" if is_test else "imagesTr"
+    image_suffix = "_0000"
+
+    for subject in particpant_to_sample_dict.keys():
+        for image in particpant_to_sample_dict[subject]:
+            case_id = bids_to_nnunet_dict[str((subject, image))]
+            image_path = os.path.join(
+                datapath, subject, "micr", f"{subject}_{image}_SEM.png"
+            )
+            img = cv2.imread(str(image_path), cv2.IMREAD_GRAYSCALE)
+            fname = f"{dataset_name}_{case_id:03d}{image_suffix}.png"
+            cv2.imwrite(os.path.join(out_folder, folder_type, fname), img)
+
+
+def process_labels(
+    datapath: Path,
+    out_folder: str,
+    particpant_to_sample_dict: Dict[str, List[str]],
+    bids_to_nnunet_dict: Dict[str, int],
+    dataset_name: str,
+    label_type: Literal["axonmyelin", "myelin", "axon"] = "axonmyelin",
+):
+    """
+    Processes label images from a list of subjects, matching each image with the label having the largest 'N' number.
+
+    Parameters
+    ----------
+    datapath : Path
+        Path to the data directory.
+    out_folder : str
+        Output directory to save processed label images.
+    particpant_to_sample_dict : Dict[str, List[str]]
+        Dictionary mapping participant IDs to sample IDs.
+    bids_to_nnunet_dict : Dict[str, int]
+        Dictionary mapping subject names to case IDs.
+    dataset_name : str
+        Name of the dataset.
+    """
+    for subject in particpant_to_sample_dict.keys():
+        for image in particpant_to_sample_dict[subject]:
+            case_id = bids_to_nnunet_dict[str((subject, image))]
+            label_path = os.path.join(
+                datapath,
+                "derivatives",
+                "labels",
+                subject,
+                "micr",
+                f"{subject}_{image}_SEM_seg-{label_type}-manual.png",
+            )
+            label = cv2.imread(str(label_path), cv2.IMREAD_GRAYSCALE)
+            mapping_dict = {0: 0, 127: 1, 128: 1, 130: 1, 233: 2, 255: 2}
+            label = np.vectorize(mapping_dict.get)(label)
+            fname = f"{dataset_name}_{case_id:03d}.png"
+            cv2.imwrite(os.path.join(out_folder, "labelsTr", fname), label)
+
+
+def create_bids_to_nnunet_dict(file_path: Path) -> Dict[str, int]:
+    """
+    Creates a dictionary mapping unique (sample_id, participant_id) tuples to case IDs.
+
+    Parameters
+    ----------
+    file_path : Path
+        Path to the file containing the list of subjects.
+
+    Returns
+    -------
+    Dict[str, int]
+        Dictionary mapping unique (sample_id, participant_id) tuples to case IDs.
+    """
+    with open(file_path, "r") as file:
+        reader = csv.reader(file, delimiter="\t")
+        next(reader)  # Skip the header row
+        bids_to_nnunet_dict = {}
+        num = 1
+        for row in reader:
+            key = str((row[1], row[0]))  # (participant_id, sample_id)
+            bids_to_nnunet_dict[key] = num
+            num += 1
+        return bids_to_nnunet_dict
+
+
+def particpant_to_sample(file_path: Path) -> Dict[str, str]:
+    """
+    Creates a dictionary mapping participant IDs to sample IDs.
+
+    Parameters
+    ----------
+    file_path : Path
+        Path to the file containing the list of subjects.
+
+    Returns
+    -------
+    Dict[str, str]
+        Dictionary mapping participant IDs to sample IDs.
+    """
+    with open(file_path, "r") as file:
+        reader = csv.reader(file, delimiter="\t")
+        next(reader)  # Skip the header row
+        particpant_to_sample_dict = {}
+        for row in reader:
+            participant_id = row[1]
+            sample_id = row[0]
+            if participant_id in particpant_to_sample_dict:
+                particpant_to_sample_dict[participant_id].append(sample_id)
+            else:
+                particpant_to_sample_dict[participant_id] = [sample_id]
+        return particpant_to_sample_dict
+
+
+def main(args):
+    """
+    Main function to process dataset for nnUNet.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Command line arguments containing DATAPATH and TARGETDIR.
+    """
+    dataset_name = args.DATASETNAME
+    description = args.DESCRIPTION
+    datapath = Path(args.DATAPATH)
+    target_dir = Path(args.TARGETDIR)
+    train_test_split_path = Path(args.SPLITJSON)
+
+    out_folder = os.path.join(target_dir, "nnUNet_raw", f"Dataset001_{dataset_name}")
+    create_directories(out_folder, ["imagesTr", "labelsTr", "imagesTs"])
+
+    bids_to_nnunet_dict = create_bids_to_nnunet_dict(
+        os.path.join(datapath, "samples.tsv")
+    )
+
+    with open(train_test_split_path, "r") as f:
+        train_test_split_dict = json.load(f)
+
+    train_participant_to_sample_dict = {}
+    test_participant_to_sample_dict = {}
+
+    for sample_id, participant_id in train_test_split_dict["train"].items():
+        if participant_id in train_participant_to_sample_dict:
+            train_participant_to_sample_dict[participant_id].append(sample_id)
+        else:
+            train_participant_to_sample_dict[participant_id] = [sample_id]
+
+    for sample_id, participant_id in train_test_split_dict["test"].items():
+        if participant_id in test_participant_to_sample_dict:
+            test_participant_to_sample_dict[participant_id].append(sample_id)
+        else:
+            test_participant_to_sample_dict[participant_id] = [sample_id]
+
+    dataset_info = {
+        "name": dataset_name,
+        "description": description,
+        "labels": {"background": 0, "myelin": 1, "axon": 2},
+        "channel_names": {"0": "rescale_to_0_1"},
+        "numTraining": len(
+            [
+                image
+                for images in train_participant_to_sample_dict.values()
+                for image in images
+            ]
+        ),
+        "numTest": len(
+            [
+                image
+                for images in test_participant_to_sample_dict.values()
+                for image in images
+            ]
+        ),
+        "file_ending": ".png",
+    }
+    save_json(dataset_info, os.path.join(out_folder, "dataset.json"))
+
+    process_images(
+        datapath,
+        out_folder,
+        train_participant_to_sample_dict,
+        bids_to_nnunet_dict,
+        dataset_name,
+        is_test=False,
+    )
+    process_labels(
+        datapath,
+        out_folder,
+        train_participant_to_sample_dict,
+        bids_to_nnunet_dict,
+        dataset_name,
+        label_type=args.LABELTYPE,
+    )
+    process_images(
+        datapath,
+        out_folder,
+        test_participant_to_sample_dict,
+        bids_to_nnunet_dict,
+        dataset_name,
+        is_test=True,
+    )
+
+    save_json(
+        bids_to_nnunet_dict, os.path.join(target_dir, "subject_to_case_identifier.json")
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("DATAPATH", help="Path to the original dataset in BIDS format")
+    parser.add_argument(
+        "--TARGETDIR",
+        default=".",
+        help="Target directory for the new dataset, defaults to current directory",
+    )
+    parser.add_argument(
+        "--DATASETNAME",
+        default="SEM",
+        help="Name of the new dataset, defaults to SEM",
+    )
+    parser.add_argument(
+        "--DESCRIPTION",
+        default="SEM segmentation dataset for nnUNetv2",
+        help="Description of the new dataset, defaults to SEM segmentation dataset for nnUNetv2",
+    )
+    parser.add_argument(
+        "--SPLITJSON",
+        default="nn_unet_scripts/train_test_split.json",
+        help="Path to the train_test_split.json file",
+    )
+    parser.add_argument(
+        "--LABELTYPE",
+        default="axonmyelin",
+        help="Type of label to use. Options are 'axonmyelin', 'myelin', or 'axon'. Defaults to 'axonmyelin'",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py
+++ b/nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py
@@ -216,8 +216,11 @@ def main(args):
     target_dir = Path(args.TARGETDIR)
     train_test_split_path = Path(args.SPLITJSON)
     label_type = args.LABELTYPE
+    dataset_id = str(args.DATASETID).zfill(3)
 
-    out_folder = os.path.join(target_dir, "nnUNet_raw", f"Dataset001_{dataset_name}")
+    out_folder = os.path.join(
+        target_dir, "nnUNet_raw", f"Dataset{dataset_id}_{dataset_name}"
+    )
     create_directories(out_folder, ["imagesTr", "labelsTr", "imagesTs"])
 
     bids_to_nnunet_dict = create_bids_to_nnunet_dict(
@@ -326,6 +329,12 @@ if __name__ == "__main__":
         "--LABELTYPE",
         default="axonmyelin",
         help="Type of label to use. Options are 'axonmyelin', 'myelin', or 'axon'. Defaults to 'axonmyelin'",
+    )
+    parser.add_argument(
+        "--DATASETID",
+        default=1,
+        type=int,
+        help="ID of the dataset. This ID is formatted with 3 digits. For example, 1 becomes '001', 23 becomes '023', etc. Defaults to 1",
     )
     args = parser.parse_args()
     main(args)

--- a/nn_unet_scripts/setup_nnunet.sh
+++ b/nn_unet_scripts/setup_nnunet.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 # This script sets up the nnUNet environment and runs the preprocessing and dataset integrity verification
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 PATH_TO_ORIGINAL_DATASET RESULTS_DIR"
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 PATH_TO_ORIGINAL_DATASET RESULTS_DIR [DATASET_ID] [LABEL_TYPE] [DATASET_NAME]"
     exit 1
 fi
 
 config="2d"                     
-dataset_id=1   
+
 
 PATH_TO_ORIGINAL_DATASET=$1
 RESULTS_DIR=$(realpath $2)
+dataset_id=${3:-1}
+label_type=${4:-"axonmyelin"} # 'axonmyelin', 'myelin', or 'axon'. Defaults to 'axonmyelin'
+dataset_name=${5:-"SEM"}
 
 echo "-------------------------------------------------------"
 echo "Converting dataset to nnUNetv2 format"
 echo "-------------------------------------------------------"
 
 # Run the conversion script
-python nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py $PATH_TO_ORIGINAL_DATASET --TARGETDIR $RESULTS_DIR
+python nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py $PATH_TO_ORIGINAL_DATASET --TARGETDIR $RESULTS_DIR --DATASETID $dataset_id --LABELTYPE $label_type --DATASETNAME $dataset_name
 
 # Set up the necessary environment variables
 export nnUNet_raw="$RESULTS_DIR/nnUNet_raw"

--- a/nn_unet_scripts/setup_nnunet.sh
+++ b/nn_unet_scripts/setup_nnunet.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This script sets up the nnUNet environment and runs the preprocessing and dataset integrity verification
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 PATH_TO_ORIGINAL_DATASET RESULTS_DIR"
+    exit 1
+fi
+
+config="2d"                     
+dataset_id=1   
+
+PATH_TO_ORIGINAL_DATASET=$1
+RESULTS_DIR=$(realpath $2)
+
+echo "-------------------------------------------------------"
+echo "Converting dataset to nnUNetv2 format"
+echo "-------------------------------------------------------"
+
+# Run the conversion script
+python nn_unet_scripts/convert_from_bids_to_nnunetv2_format.py $PATH_TO_ORIGINAL_DATASET --TARGETDIR $RESULTS_DIR
+
+# Set up the necessary environment variables
+export nnUNet_raw="$RESULTS_DIR/nnUNet_raw"
+export nnUNet_preprocessed="$RESULTS_DIR/nnUNet_preprocessed"
+export nnUNet_results="$RESULTS_DIR/nnUNet_results"
+
+echo "-------------------------------------------------------"
+echo "Running preprocessing and verifying dataset integrity"
+echo "-------------------------------------------------------"
+
+nnUNetv2_plan_and_preprocess -d ${dataset_id} --verify_dataset_integrity -c ${config}

--- a/nn_unet_scripts/train_test_split.json
+++ b/nn_unet_scripts/train_test_split.json
@@ -1,0 +1,16 @@
+{
+    "train": {
+        "sample-data1": "sub-rat1",
+        "sample-data5": "sub-rat2",
+        "sample-data9": "sub-rat3",
+        "sample-data10": "sub-rat3",
+        "sample-data11": "sub-rat3",
+        "sample-data12": "sub-rat4",
+        "sample-data14": "sub-rat5",
+        "sample-Maxo03img60": "sub-rat7",
+        "sample-V915": "sub-rat8"
+    },
+    "test": {
+        "sample-data15": "sub-rat6"
+    }
+}


### PR DESCRIPTION
## Overview
This pull request introduces a script for converting from the BIDS format to the nnUnetv2 format, along with a few other updates. Other changes include a new JSON file for image splits and updates to documentation and `.gitignore`.

## Changes

### Added
- **BIDS to nnUnetv2 Conversion Script:** We've added a script (`convert_from_bids_to_nnunetv2_format`) that converts data from the BIDS format to the nnUnetv2 format, facilitating the use of nnUnet for image segmentation.
- **Train/Test Split JSON File:** A JSON file is included, specifying the train and test images, based on the previous train-test split used by `ivadomed` models. 
- **Environment Dependencies:** The `environment.yaml` file lists all dependencies required for running the nnunet scripts, making it easier for new users to set up their environment.
- **nnUnet Folder Structure in `.gitignore`:** The `.gitignore` file now includes nnUnet-specific folders and the `subject_to_case_identifier.json` file, as well as the `.vscode/` folder.

### Updated
- **Documentation:** Instructions on using nnUNetv2 have been added to the `README.md` file, offering straightforward guidance for users to start with the new conversion script.

